### PR TITLE
Allow gets from multiple different pools

### DIFF
--- a/Network/Riak/Montage/Types.hs
+++ b/Network/Riak/Montage/Types.hs
@@ -34,7 +34,7 @@ class (Show a) => MontageRiakValue a where
     ensureEval r@(RiakMontagePb _ _) = r
 
 class Poolable p where
-    chooser :: p -> Bucket -> Pool Connection
+    chooser :: p -> Bucket -> [Pool Connection]
 
 instance (MontageRiakValue a) => Resolvable (RiakRecord a) where
     -- force deserialization for resolution
@@ -106,7 +106,7 @@ data (MontageRiakValue a) => RiakRequest a = RiakGet Bucket Key
 
 type RiakResponse a = Maybe (RiakRecord a, VClock, Maybe Int)
 
-type PoolChooser = Bucket -> Pool Connection
+type PoolChooser = Bucket -> [Pool Connection]
 
 type RawValue = S.ByteString
 type Specifier = T.Text

--- a/examples/basic_proxy.hs
+++ b/examples/basic_proxy.hs
@@ -57,7 +57,7 @@ data ResObject = ResObjectUserInfo UserInfo
   deriving (Show)
 
 instance Poolable (Pool Connection) where
-  chooser p _ = p
+  chooser p _ = [p]
 
 instance MontageRiakValue ResObject where
   getPB "u-info" = BucketSpec

--- a/examples/basic_proxy_pools.hs
+++ b/examples/basic_proxy_pools.hs
@@ -63,9 +63,9 @@ data Pools = Pools {
 
 -- multiple pools
 instance Poolable Pools where
-  chooser ps "u-info" = poolA ps
-  chooser ps "u-event" = poolA ps
-  chooser ps "u-name" = poolB ps
+  chooser ps "u-info" = [poolA ps]
+  chooser ps "u-event" = [poolA ps]
+  chooser ps "u-name" = [poolB ps]
 
 instance MontageRiakValue ResObject where
   getPB "u-info" = BucketSpec


### PR DESCRIPTION
Issue gets to >1 cluster sequentially; if the first pool in the pool list
doesn't have the value, try pool 1, then pool 2, etc. Useful for, e.g.,
migrating data from one cluster to another.

Sets and deletes always go to the first cluster currently.
